### PR TITLE
Add vs2017 docker file based on jashook/vs2017-build-tools-enterprise

### DIFF
--- a/windows/vs2017/enterprise/Dockerfile
+++ b/windows/vs2017/enterprise/Dockerfile
@@ -1,0 +1,21 @@
+# Use the latest Windows Server Core image with .NET Framework 4.8.
+FROM jashook/vs2017-build-tools-enterprise:latest
+
+# download 7z for unzip
+ADD https://www.7-zip.org/a/7z1900-x64.exe C:/BuildTools/7z1900-x64.exe
+RUN C:\BuildTools\7z1900-x64.exe /S /D="C:\7z"
+#RUN DEL C:\BuildTools\7z1900-x64.exe
+
+# download CMake and unzip package
+ADD https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-win64-x64.zip C:/BuildTools/cmake-win64-x64.zip
+RUN MD C:\cmake
+RUN C:\7z\7z.exe x -oC:\cmake C:/BuildTools/cmake-win64-x64.zip
+RUN setx -m PATH "%PATH%;C:\cmake\cmake-3.15.4-win64-x64\bin"
+#RUN DEL C:\BuildTools\cmake-win64-x64.zip
+
+# download YASM
+RUN MD C:\yasm
+ADD http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe C:/yasm/yasm.exe
+RUN setx -m PATH "%PATH%;C:\yasm"
+
+ENTRYPOINT C:\BuildTools\Common7\Tools\VsDevCmd.bat && cmd.exe


### PR DESCRIPTION
add build tools: cmake, yasm

Known Issue:
cmake configuration failed--->
-- Check for working C compiler: C:/BuildTools/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe
CMake Error: Remove failed on file: C:/av1/Build/windows/CMakeFiles/CMakeTmp/Debug/cmTC_ed182.pdb: System Error: No such file or directory
-- Check for working C compiler: C:/BuildTools/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe -- broken
CMake Error at C:/cmake/cmake-3.15.4-win64-x64/share/cmake-3.15/Modules/CMakeTestCCompiler.cmake:60 (message):
  The C compiler

    "C:/BuildTools/VC/Tools/MSVC/14.12.25827/bin/Hostx86/x64/cl.exe"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: C:/av1/Build/windows/CMakeFiles/CMakeTmp

    Run Build Command(s):C:/BuildTools/MSBuild/15.0/Bin/MSBuild.exe cmTC_ed182.vcxproj /p:Configuration=Debug /p:Platform=x64 /p:VisualStudioVersion=15.0 /v:m && Microsoft (R) Build Engine version 15.5.180.51428 for .NET Framework
    Copyright (C) Microsoft Corporation. All rights reserved.

      testCCompiler.c
      Microsoft (R) C/C++ Optimizing Compiler Version 19.12.25835 for x64
      Copyright (C) Microsoft Corporation.  All rights reserved.

      cl /c /Zi /W3 /WX- /diagnostics:classic /Od /Ob0 /D WIN32 /D _WINDOWS /D "CMAKE_INTDIR=\"Debug\"" /D _MBCS /Gm- /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Fo"cmTC_ed182.dir\Debug\\" /Fd"cmTC_ed182.dir\Debug\vc141.pdb" /Gd /TC /errorReport:queue C:\av1\Build\windows\CMakeFiles\CMakeTmp\testCCompiler.c

    LINK : fatal error LNK1318: Unexpected PDB error; RPC (23) '(0x000006E7)' [C:\av1\Build\windows\CMakeFiles\CMakeTmp\cmTC_ed182.vcxproj]